### PR TITLE
Adds gen_server name registration API

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ Types:
 > You may re-register a process multiple times, for example if you need to update its metadata.
 > When a process gets registered, Syn will automatically monitor it.
 
+Processes can also be registered as gen_server names, by usage of via-tuples.
+This way, you can use the gen_server API with these tuples without referring to the Pid directly.
+
+```erlang
+Tuple = {via, syn, <<"your process name">>}.
+gen_server:start_link(Tuple, your_module, []).
+gen_server:call(Tuple, your_message).
+```
 
 To retrieve a Pid from a Key:
 

--- a/src/syn.erl
+++ b/src/syn.erl
@@ -36,6 +36,12 @@
 -export([find_by_pid/1, find_by_pid/2]).
 -export([registry_count/0, registry_count/1]).
 
+%% registry for gen_server name via-tuples
+-export([register_name/2]).
+-export([unregister_name/1]).
+-export([whereis_name/1]).
+-export([send/2]).
+
 %% groups
 -export([join/2]).
 -export([leave/2]).
@@ -97,6 +103,32 @@ registry_count() ->
 -spec registry_count(Node :: atom()) -> non_neg_integer().
 registry_count(Node) ->
     syn_registry:count(Node).
+
+-spec register_name(Name :: term(), Pid :: pid()) -> 'yes' | 'no'.
+register_name(Name, Pid) when is_pid(Pid) ->
+    case syn_registry:register(Name, Pid) of
+      ok -> yes;
+      {error, _} -> no;
+      _ -> no
+    end.
+
+-spec unregister_name(Name :: term()) -> _.
+unregister_name(Name) ->
+    case syn_registry:unregister(Name) of
+      ok -> Name;
+      {error, _} -> nil;
+      _ -> nil
+    end.
+
+-spec whereis_name(Name :: term()) -> pid() | 'undefined'.
+whereis_name(Name) -> syn_registry:find_by_key(Name).
+
+-spec send(Name :: term(), Message :: term()) -> pid().
+send(Name, Message) ->
+    case whereis_name(Name) of
+      undefined -> {badarg, {Name, Message}};
+      Pid -> Pid ! Message, Pid
+    end.
 
 -spec join(Name :: any(), Pid :: pid()) -> ok.
 join(Name, Pid) ->

--- a/test/syn_test_gen_server.erl
+++ b/test/syn_test_gen_server.erl
@@ -1,0 +1,69 @@
+%% ==========================================================================================================
+%% Syn - A global Process Registry and Process Group manager.
+%%
+%% The MIT License (MIT)
+%%
+%% Copyright (c) 2015 Roberto Ostinelli <roberto@ostinelli.net> and Neato Robotics, Inc.
+%%
+%% Permission is hereby granted, free of charge, to any person obtaining a copy
+%% of this software and associated documentation files (the "Software"), to deal
+%% in the Software without restriction, including without limitation the rights
+%% to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+%% copies of the Software, and to permit persons to whom the Software is
+%% furnished to do so, subject to the following conditions:
+%%
+%% The above copyright notice and this permission notice shall be included in
+%% all copies or substantial portions of the Software.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+%% IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+%% FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+%% AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+%% LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+%% OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+%% THE SOFTWARE.
+%% ==========================================================================================================
+-module(syn_test_gen_server).
+
+-behaviour(gen_server).
+
+-export([start_link/2,
+         stop/1]).
+
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+start_link(Parent, Name) ->
+    gen_server:start_link(Name, ?MODULE, Parent, []).
+
+stop(Server) ->
+    gen_server:cast(Server, stop).
+
+init(State) ->
+    {ok, State}.
+
+handle_call(_Request, _From, State) ->
+    {reply, call_received, State}.
+
+handle_cast(stop, State) ->
+    State ! stop_received,
+    {stop, normal, State};
+
+handle_cast(_Msg, State) ->
+    State ! cast_received,
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    State ! info_received,
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.


### PR DESCRIPTION
Copied from and extended the existing PR #18 

@ostinelli As mentioned in the other PR, gproc also supports sending casts to groups, i.e. making async group messages transparent - I'd suggest to also implement that, but have no clue what path to follow. We could either simply try and group-`publish` to the given name in `send/2` if the lookup fails with `undefined` - or we could do it like gproc and actually take a tuple for registration, like:

E.g.:

```erlang
gen_server:start_link({via, syn, {group, Name}}, ...
gen_server:start_link({via, syn, {proc, Name}}, ...
```
And then we can match on that within `send/2`