### PR TITLE
Ignore `shutdown` as process death reason too

### DIFF
--- a/src/syn_registry.erl
+++ b/src/syn_registry.erl
@@ -255,6 +255,7 @@ handle_info({'EXIT', Pid, Reason}, #state{
                 %% log
                 case Reason of
                     normal -> ok;
+                    shutdown -> ok;
                     killed -> ok;
                     _ ->
                         error_logger:error_msg("Process with key ~p and pid ~p exited with reason: ~p", [Key0, Pid, Reason])


### PR DESCRIPTION
The `shutdown` reason for process death currently leads to an error message, even though its a normal reason for processes of a supervision chain.