### PR TITLE
Crash in syn:leave/2

### DIFF
--- a/src/syn_groups.erl
+++ b/src/syn_groups.erl
@@ -180,7 +180,7 @@ handle_call({join, Name, Pid, Meta}, _From, State) ->
 handle_call({leave, Name, Pid}, _From, State) ->
     case find_by_pid_and_name(Pid, Name) of
         undefined ->
-            {error, pid_not_in_group};
+            {reply, {error, pid_not_in_group}, State};
         Process ->
             %% remove from table
             remove_process(Process),

--- a/test/syn_groups_SUITE.erl
+++ b/test/syn_groups_SUITE.erl
@@ -214,6 +214,8 @@ single_node_leave(_Config) ->
     %% retrieve
     [] = syn:get_members(<<"my group">>),
     false = syn:member(Pid, <<"my group">>),
+    %% leave before join
+    {error, pid_not_in_group} = syn:leave(<<"my group">>, Pid),
     %% join
     ok = syn:join(<<"my group">>, Pid),
     %% retrieve


### PR DESCRIPTION
Calling `syn:leave/2` with not-yet-joined pid results in the following error:
```
$ rebar shell
==> syn (shell)
Erlang/OTP 19 [erts-8.1] [source] [64-bit] [smp:2:2] [async-threads:10] [hipe] [kernel-poll:false]

Eshell V8.1  (abort with ^G)
1> syn:start().
ok
2> syn:init().
ok
3> syn:leave(a, self()).

=INFO REPORT==== 4-Nov-2016::16:09:35 ===
Terminating syn_groups with reason: {bad_return_value,
                                     {error,pid_not_in_group}}
=ERROR REPORT==== 4-Nov-2016::16:09:35 ===
** Generic server syn_groups terminating 
** Last message in was {leave,a,<0.64.0>}
** When Server state == {state,undefined,undefined}
** Reason for termination == 
** {bad_return_value,{error,pid_not_in_group}}
** exception exit: {{bad_return_value,{error,pid_not_in_group}},
                    {gen_server,call,
                                [{syn_groups,nonode@nohost},{leave,a,<0.64.0>}]}}
     in function  gen_server:call/2 (gen_server.erl, line 204)
```
`syn:leave/2` should instead return `{error, pid_not_in_group}`.

Thanks in advance!