### PR TITLE
Added check during mnesia clusterisation

### DIFF
--- a/src/syn_backbone.erl
+++ b/src/syn_backbone.erl
@@ -40,10 +40,7 @@
 initdb() ->
     %% ensure all nodes are added
     ClusterNodes = [node() | nodes()],
-    case mnesia:change_config(extra_db_nodes, ClusterNodes) of
-        {ok, Nodes} -> error_logger:info_msg("Mnesia replication was successfully created at nodes: ~p", [Nodes]);
-        {error, Reason} -> error_logger:error_msg("Error while creating Mnesia replication for reason: ~p", [Reason])
-    end,
+    {ok, _} = mnesia:change_config(extra_db_nodes, ClusterNodes),
     %% create tables
     create_table(syn_registry_table, [
         {type, set},

--- a/src/syn_backbone.erl
+++ b/src/syn_backbone.erl
@@ -40,7 +40,10 @@
 initdb() ->
     %% ensure all nodes are added
     ClusterNodes = [node() | nodes()],
-    mnesia:change_config(extra_db_nodes, ClusterNodes),
+    case mnesia:change_config(extra_db_nodes, ClusterNodes) of
+        {ok, Nodes} -> error_logger:info_msg("Mnesia replication was successfully created at nodes: ~p", [Nodes]);
+        {error, Reason} -> error_logger:error_msg("Error while creating Mnesia replication for reason: ~p", [Reason])
+    end,
     %% create tables
     create_table(syn_registry_table, [
         {type, set},


### PR DESCRIPTION
Begin of the story here #35 

There is no result check of `mnesia:change_config/2` at `syn_backbone:initdb/0`.
So if your Mnesia miss configured, `syn` will not be able to setup replication between nodes.

I just added related case statement.