### PR TITLE
remove duplicate match

### DIFF
--- a/src/syn_registry.erl
+++ b/src/syn_registry.erl
@@ -256,7 +256,6 @@ handle_info({'EXIT', Pid, Reason}, #state{
             case Reason of
                 normal -> ok;
                 shutdown -> ok;
-                shutdown -> ok;
                 {shutdown, _} -> ok;
                 killed -> ok;
                 _ ->


### PR DESCRIPTION
Self-explanatory, really: there's a duplicate match clause for shutdown