### PR TITLE
Add register_local for registering on the node where syn was called

### DIFF
--- a/src/syn.erl
+++ b/src/syn.erl
@@ -31,6 +31,7 @@
 
 %% registry
 -export([register/2, register/3]).
+-export([register_local/2, register_local/3]).
 -export([unregister/1]).
 -export([find_by_key/1, find_by_key/2]).
 -export([find_by_pid/1, find_by_pid/2]).
@@ -81,6 +82,14 @@ register(Key, Pid, Meta) ->
 -spec unregister(Key :: any()) -> ok | {error, undefined}.
 unregister(Key) ->
     syn_registry:unregister(Key).
+
+-spec register_local(Key :: any(), Pid :: pid()) -> ok | {error, taken | pid_already_registered}.
+register_local(Key, Pid) ->
+    syn_registry:register_local(Key, Pid).
+
+-spec register_local(Key :: any(), Pid :: pid(), Meta :: any()) -> ok | {error, taken | pid_already_registered}.
+register_local(Key, Pid, Meta) ->
+    syn_registry:register_local(Key, Pid, Meta).
 
 -spec find_by_key(Key :: any()) -> pid() | undefined.
 find_by_key(Key) ->

--- a/src/syn_registry.erl
+++ b/src/syn_registry.erl
@@ -28,7 +28,7 @@
 
 %% API
 -export([start_link/0]).
--export([register/2, register/3]).
+-export([register/2, register/3, register_local/2, register_local/3]).
 -export([unregister/1]).
 -export([find_by_key/1, find_by_key/2]).
 -export([find_by_pid/1, find_by_pid/2]).
@@ -101,6 +101,14 @@ unregister(Key) ->
             Node = node(Process#syn_registry_table.pid),
             gen_server:call({?MODULE, Node}, {unregister_on_node, Key})
     end.
+
+-spec register_local(Key :: any(), Pid :: pid()) -> ok | {error, taken | pid_already_registered}.
+register_local(Key, Pid) when is_pid(Pid) ->
+    register_local(Key, Pid, undefined).
+
+-spec register_local(Key :: any(), Pid :: pid(), Meta :: any()) -> ok | {error, taken | pid_already_registered}.
+register_local(Key, Pid, Meta) when is_pid(Pid) ->
+    gen_server:call(?MODULE, {register_on_node, Key, Pid, Meta}).
 
 -spec count() -> non_neg_integer().
 count() ->

--- a/test/syn_registry_local_SUITE.erl
+++ b/test/syn_registry_local_SUITE.erl
@@ -1,0 +1,359 @@
+%% ==========================================================================================================
+%% Syn - A global Process Registry and Process Group manager.
+%%
+%% The MIT License (MIT)
+%%
+%% Copyright (c) 2015 Roberto Ostinelli <roberto@ostinelli.net> and Neato Robotics, Inc.
+%%
+%% Permission is hereby granted, free of charge, to any person obtaining a copy
+%% of this software and associated documentation files (the "Software"), to deal
+%% in the Software without restriction, including without limitation the rights
+%% to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+%% copies of the Software, and to permit persons to whom the Software is
+%% furnished to do so, subject to the following conditions:
+%%
+%% The above copyright notice and this permission notice shall be included in
+%% all copies or substantial portions of the Software.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+%% IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+%% FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+%% AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+%% LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+%% OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+%% THE SOFTWARE.
+%% ==========================================================================================================
+-module(syn_registry_local_SUITE).
+
+%% callbacks
+-export([all/0]).
+-export([init_per_suite/1, end_per_suite/1]).
+-export([groups/0, init_per_group/2, end_per_group/2]).
+-export([init_per_testcase/2, end_per_testcase/2]).
+
+%% tests
+-export([
+    two_nodes_when_mnesia_is_ram_find_by_key/1,
+    two_nodes_when_mnesia_is_ram_find_by_key_with_meta/1,
+    two_nodes_when_mnesia_is_ram_process_count/1,
+    two_nodes_when_mnesia_is_ram_callback_on_process_exit/1,
+    two_nodes_when_mnesia_is_disc_find_by_pid/1
+]).
+
+%% internals
+-export([registry_process_exit_callback_dummy/4]).
+
+%% include
+-include_lib("common_test/include/ct.hrl").
+
+
+%% ===================================================================
+%% Callbacks
+%% ===================================================================
+
+%% -------------------------------------------------------------------
+%% Function: all() -> GroupsAndTestCases | {skip,Reason}
+%% GroupsAndTestCases = [{group,GroupName} | TestCase]
+%% GroupName = atom()
+%% TestCase = atom()
+%% Reason = term()
+%% -------------------------------------------------------------------
+all() ->
+    [
+        {group, two_nodes_process_registration}
+    ].
+
+%% -------------------------------------------------------------------
+%% Function: groups() -> [Group]
+%% Group = {GroupName,Properties,GroupsAndTestCases}
+%% GroupName = atom()
+%% Properties = [parallel | sequence | Shuffle | {RepeatType,N}]
+%% GroupsAndTestCases = [Group | {group,GroupName} | TestCase]
+%% TestCase = atom()
+%% Shuffle = shuffle | {shuffle,{integer(),integer(),integer()}}
+%% RepeatType = repeat | repeat_until_all_ok | repeat_until_all_fail |
+%%			   repeat_until_any_ok | repeat_until_any_fail
+%% N = integer() | forever
+%% -------------------------------------------------------------------
+groups() ->
+    [
+        {two_nodes_process_registration, [shuffle], [
+            two_nodes_when_mnesia_is_ram_find_by_key,
+            two_nodes_when_mnesia_is_ram_find_by_key_with_meta,
+            two_nodes_when_mnesia_is_ram_process_count,
+            two_nodes_when_mnesia_is_ram_callback_on_process_exit,
+            two_nodes_when_mnesia_is_disc_find_by_pid
+        ]}
+    ].
+%% -------------------------------------------------------------------
+%% Function: init_per_suite(Config0) ->
+%%				Config1 | {skip,Reason} |
+%%              {skip_and_save,Reason,Config1}
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%% -------------------------------------------------------------------
+init_per_suite(Config) ->
+    %% config
+    [
+        {slave_node_short_name, syn_slave}
+        | Config
+    ].
+
+%% -------------------------------------------------------------------
+%% Function: end_per_suite(Config0) -> void() | {save_config,Config1}
+%% Config0 = Config1 = [tuple()]
+%% -------------------------------------------------------------------
+end_per_suite(_Config) -> ok.
+
+%% -------------------------------------------------------------------
+%% Function: init_per_group(GroupName, Config0) ->
+%%				Config1 | {skip,Reason} |
+%%              {skip_and_save,Reason,Config1}
+%% GroupName = atom()
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%% -------------------------------------------------------------------
+init_per_group(two_nodes_process_registration, Config) ->
+    %% start slave
+    SlaveNodeShortName = proplists:get_value(slave_node_short_name, Config),
+    {ok, SlaveNode} = syn_test_suite_helper:start_slave(SlaveNodeShortName),
+    %% config
+    [
+        {slave_node, SlaveNode}
+        | Config
+    ];
+init_per_group(_GroupName, Config) -> Config.
+
+%% -------------------------------------------------------------------
+%% Function: end_per_group(GroupName, Config0) ->
+%%				void() | {save_config,Config1}
+%% GroupName = atom()
+%% Config0 = Config1 = [tuple()]
+%% -------------------------------------------------------------------
+end_per_group(two_nodes_process_registration, Config) ->
+    %% get slave node name
+    SlaveNodeShortName = proplists:get_value(slave_node_short_name, Config),
+    %% stop slave
+    syn_test_suite_helper:stop_slave(SlaveNodeShortName);
+end_per_group(_GroupName, _Config) ->
+    ok.
+
+% ----------------------------------------------------------------------------------------------------------
+% Function: init_per_testcase(TestCase, Config0) ->
+%				Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+% TestCase = atom()
+% Config0 = Config1 = [tuple()]
+% Reason = term()
+% ----------------------------------------------------------------------------------------------------------
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+% ----------------------------------------------------------------------------------------------------------
+% Function: end_per_testcase(TestCase, Config0) ->
+%				void() | {save_config,Config1} | {fail,Reason}
+% TestCase = atom()
+% Config0 = Config1 = [tuple()]
+% Reason = term()
+% ----------------------------------------------------------------------------------------------------------
+end_per_testcase(_TestCase, Config) ->
+    %% get slave
+    SlaveNode = proplists:get_value(slave_node, Config),
+    syn_test_suite_helper:clean_after_test(SlaveNode).
+
+%% ===================================================================
+%% Tests
+%% ===================================================================
+
+two_nodes_when_mnesia_is_ram_find_by_key(Config) ->
+    %% get slave
+    SlaveNode = proplists:get_value(slave_node, Config),
+    %% set schema location
+    application:set_env(mnesia, schema_location, ram),
+    rpc:call(SlaveNode, mnesia, schema_location, [ram]),
+    %% start
+    ok = syn:start(),
+    ok = syn:init(),
+    ok = rpc:call(SlaveNode, syn, start, []),
+    ok = rpc:call(SlaveNode, syn, init, []),
+    timer:sleep(100),
+    %% start process
+    Pid = syn_test_suite_helper:start_process(),
+    %% retrieve
+    undefined = syn:find_by_key(<<"my proc">>),
+    undefined = rpc:call(SlaveNode, syn, find_by_key, [<<"my proc">>]),
+    %% register
+    ok = syn:register_local(<<"my proc">>, Pid),
+    %% retrieve
+    Pid = syn:find_by_key(<<"my proc">>),
+    Pid = rpc:call(SlaveNode, syn, find_by_key, [<<"my proc">>]),
+    %% kill process
+    rpc:call(SlaveNode, syn, unregister, [<<"my proc">>]),
+    timer:sleep(100),
+    %% retrieve
+    undefined = syn:find_by_key(<<"my proc">>),
+    undefined = rpc:call(SlaveNode, syn, find_by_key, [<<"my proc">>]).
+
+two_nodes_when_mnesia_is_ram_find_by_key_with_meta(Config) ->
+    %% get slave
+    SlaveNode = proplists:get_value(slave_node, Config),
+    %% set schema location
+    application:set_env(mnesia, schema_location, ram),
+    rpc:call(SlaveNode, mnesia, schema_location, [ram]),
+    %% start
+    ok = syn:start(),
+    ok = syn:init(),
+    ok = rpc:call(SlaveNode, syn, start, []),
+    ok = rpc:call(SlaveNode, syn, init, []),
+    timer:sleep(100),
+    %% start process
+    Pid1 = syn_test_suite_helper:start_process(),
+    Pid2 = syn_test_suite_helper:start_process(),
+    %% retrieve
+    undefined = syn:find_by_key(<<"my proc 1">>),
+    undefined = rpc:call(SlaveNode, syn, find_by_key, [<<"my proc 1">>]),
+    undefined = syn:find_by_key(<<"my proc 2">>),
+    undefined = rpc:call(SlaveNode, syn, find_by_key, [<<"my proc 2">>]),
+    %% register
+    Meta = [{some, 1}, {meta, <<"data">>}],
+    ok = syn:register_local(<<"my proc 1">>, Pid1, Meta),
+    ok = syn:register_local(<<"my proc 2">>, Pid2),
+    %% retrieve
+    {Pid1, Meta} = syn:find_by_key(<<"my proc 1">>, with_meta),
+    {Pid1, Meta} = rpc:call(SlaveNode, syn, find_by_key, [<<"my proc 1">>, with_meta]),
+    {Pid2, undefined} = syn:find_by_key(<<"my proc 2">>, with_meta),
+    {Pid2, undefined} = rpc:call(SlaveNode, syn, find_by_key, [<<"my proc 2">>, with_meta]),
+    %% kill process
+    syn_test_suite_helper:kill_process(Pid1),
+    syn_test_suite_helper:kill_process(Pid2),
+    timer:sleep(100),
+    %% retrieve
+    undefined = syn:find_by_key(<<"my proc 1">>),
+    undefined = rpc:call(SlaveNode, syn, find_by_key, [<<"my proc 1">>]),
+    undefined = syn:find_by_key(<<"my proc 2">>),
+    undefined = rpc:call(SlaveNode, syn, find_by_key, [<<"my proc 2">>]).
+
+two_nodes_when_mnesia_is_ram_process_count(Config) ->
+    %% get slave
+    SlaveNode = proplists:get_value(slave_node, Config),
+    CurrentNode = node(),
+    %% set schema location
+    application:set_env(mnesia, schema_location, ram),
+    rpc:call(SlaveNode, mnesia, schema_location, [ram]),
+    %% start
+    ok = syn:start(),
+    ok = syn:init(),
+    ok = rpc:call(SlaveNode, syn, start, []),
+    ok = rpc:call(SlaveNode, syn, init, []),
+    timer:sleep(100),
+    %% count
+    0 = syn:registry_count(),
+    0 = rpc:call(SlaveNode, syn, registry_count, []),
+    0 = syn:registry_count(CurrentNode),
+    0 = syn:registry_count(SlaveNode),
+    0 = rpc:call(SlaveNode, syn, registry_count, [CurrentNode]),
+    0 = rpc:call(SlaveNode, syn, registry_count, [SlaveNode]),
+    %% start processes
+    PidLocal1 = syn_test_suite_helper:start_process(),
+    PidLocal2 = syn_test_suite_helper:start_process(),
+    PidSlave = syn_test_suite_helper:start_process(SlaveNode),
+    %% register
+    ok = syn:register_local(1, PidLocal1),
+    ok = rpc:call(SlaveNode, syn, register_local, [2, PidLocal2]),
+    ok = syn:register_local(3, PidSlave),
+    timer:sleep(100),
+    %% count
+    3 = syn:registry_count(),
+    3 = rpc:call(SlaveNode, syn, registry_count, []),
+    2 = syn:registry_count(CurrentNode),
+    1 = syn:registry_count(SlaveNode),
+    2 = rpc:call(SlaveNode, syn, registry_count, [CurrentNode]),
+    1 = rpc:call(SlaveNode, syn, registry_count, [SlaveNode]),
+    %% kill processes
+    syn_test_suite_helper:kill_process(PidLocal1),
+    syn_test_suite_helper:kill_process(PidLocal2),
+    syn_test_suite_helper:kill_process(PidSlave),
+    timer:sleep(100),
+    %% count
+    0 = syn:registry_count(),
+    0 = rpc:call(SlaveNode, syn, registry_count, []),
+    0 = syn:registry_count(CurrentNode),
+    0 = syn:registry_count(SlaveNode),
+    0 = rpc:call(SlaveNode, syn, registry_count, [CurrentNode]),
+    0 = rpc:call(SlaveNode, syn, registry_count, [SlaveNode]).
+
+two_nodes_when_mnesia_is_ram_callback_on_process_exit(Config) ->
+    %% get slave
+    SlaveNode = proplists:get_value(slave_node, Config),
+    CurrentNode = node(),
+    %% set schema location
+    application:set_env(mnesia, schema_location, ram),
+    rpc:call(SlaveNode, mnesia, schema_location, [ram]),
+    %% load configuration variables from syn-test.config => this defines the callback
+    syn_test_suite_helper:set_environment_variables(),
+    syn_test_suite_helper:set_environment_variables(SlaveNode),
+    %% start
+    ok = syn:start(),
+    ok = syn:init(),
+    ok = rpc:call(SlaveNode, syn, start, []),
+    ok = rpc:call(SlaveNode, syn, init, []),
+    timer:sleep(100),
+    %% register global process
+    ResultPid = self(),
+    global:register_name(syn_register_process_SUITE_result, ResultPid),
+    %% start processes
+    PidLocal = syn_test_suite_helper:start_process(),
+    PidSlave = syn_test_suite_helper:start_process(SlaveNode),
+    %% register
+    Meta = {some, meta},
+    ok = syn:register(<<"slave">>, PidSlave),
+    ok = syn:register_local(<<"local">>, PidLocal, Meta),
+    %% kill process
+    syn_test_suite_helper:kill_process(PidLocal),
+    syn_test_suite_helper:kill_process(PidSlave),
+    %% check callback were triggered
+    receive
+        {exited, CurrentNode, <<"local">>, PidLocal, Meta, killed} -> ok
+    after 2000 ->
+        ok = registry_process_exit_callback_was_not_called_from_local_node
+    end,
+    receive
+        {exited, SlaveNode, <<"slave">>, PidSlave, undefined, killed} -> ok
+    after 2000 ->
+        ok = registry_process_exit_callback_was_not_called_from_slave_node
+    end,
+    %% unregister
+    global:unregister_name(syn_register_process_SUITE_result).
+
+two_nodes_when_mnesia_is_disc_find_by_pid(Config) ->
+    %% get slave
+    SlaveNode = proplists:get_value(slave_node, Config),
+    %% set schema location
+    application:set_env(mnesia, schema_location, disc),
+    rpc:call(SlaveNode, mnesia, schema_location, [disc]),
+    %% create schema
+    mnesia:create_schema([node(), SlaveNode]),
+    %% start
+    ok = syn:start(),
+    ok = syn:init(),
+    ok = rpc:call(SlaveNode, syn, start, []),
+    ok = rpc:call(SlaveNode, syn, init, []),
+    timer:sleep(100),
+    %% start process
+    Pid = syn_test_suite_helper:start_process(),
+    %% register
+    ok = syn:register_local(<<"my proc">>, Pid),
+    %% retrieve
+    <<"my proc">> = syn:find_by_pid(Pid),
+    <<"my proc">> = rpc:call(SlaveNode, syn, find_by_pid, [Pid]),
+    %% kill process
+    syn_test_suite_helper:kill_process(Pid),
+    timer:sleep(100),
+    %% retrieve
+    undefined = syn:find_by_pid(Pid),
+    undefined = rpc:call(SlaveNode, syn, find_by_pid, [Pid]).
+
+%% ===================================================================
+%% Internal
+%% ===================================================================
+registry_process_exit_callback_dummy(Key, Pid, Meta, Reason) ->
+    global:send(syn_register_process_SUITE_result, {exited, node(), Key, Pid, Meta, Reason}).


### PR DESCRIPTION
When 2 processes on different nodes register themselves on the same Key within a very short time, it happens that both succeed as mnesia:diryt_write does not sync within the short time period. This is fine, and the expected price for performance that syn provides.

The use case register_local is needed, to hash the Key and select a node where the registration can be serialized so only one registration will succeed on the same Key.