### PR TITLE
Notify when purging entries from remote node

### DIFF
--- a/src/syn_event_handler.erl
+++ b/src/syn_event_handler.erl
@@ -31,7 +31,7 @@
 -export([do_on_process_exit/5]).
 -export([do_on_group_process_exit/5]).
 -export([do_resolve_registry_conflict/4]).
--export([do_notify_remote_node_entries_deleted/3]).
+-export([do_on_remote_node_entries_deleted/3]).
 
 -callback on_process_exit(
     Name :: any(),
@@ -125,12 +125,12 @@ do_resolve_registry_conflict(Name, {LocalPid, LocalMeta}, {RemotePid, RemoteMeta
             {LocalPid, true}
     end.
 
--spec do_notify_remote_node_entries_deleted(
+-spec do_on_remote_node_entries_deleted(
         Node :: node(),
         Keys :: list(),
         CustomEventHandler :: module()
 ) -> any().
-do_notify_remote_node_entries_deleted(Node, Keys, CustomEventHandler) ->
+do_on_remote_node_entries_deleted(Node, Keys, CustomEventHandler) ->
     spawn(fun() ->
         case erlang:function_exported(CustomEventHandler,
                                       on_remote_node_entries_deleted, 2) of

--- a/src/syn_registry.erl
+++ b/src/syn_registry.erl
@@ -433,9 +433,9 @@ purge_registry_entries_for_remote_node(Node, CustomEventHandler) when Node =/= n
     NodePids = mnesia:dirty_select(syn_registry_table, [{MatchHead, [Guard], [IdFormat]}]),
     DelF = fun(Id) -> mnesia:dirty_delete({syn_registry_table, Id}) end,
     lists:foreach(DelF, NodePids),
-    syn_event_handler:do_notify_remote_node_entries_deleted(Node,
-                                                            NodePids,
-                                                            CustomEventHandler).
+    syn_event_handler:do_on_remote_node_entries_deleted(Node,
+                                                        NodePids,
+                                                        CustomEventHandler).
 
 -spec rebuild_monitors() -> ok.
 rebuild_monitors() ->

--- a/test/syn_test_event_handler.erl
+++ b/test/syn_test_event_handler.erl
@@ -30,6 +30,7 @@
 -export([on_process_exit/4]).
 -export([on_group_process_exit/4]).
 -export([resolve_registry_conflict/3]).
+-export([on_remote_node_entries_deleted/2]).
 
 %% ===================================================================
 %% Syn Callbacks
@@ -67,3 +68,12 @@ resolve_registry_conflict(_Name, {_LocalPid, _LocalMeta}, {RemotePid, keep_this_
     RemotePid;
 resolve_registry_conflict(_Name, {LocalPid, _LocalMeta}, {_RemotePid, _RemoteMeta}) ->
     LocalPid.
+
+
+-spec on_remote_node_entries_deleted(
+        Node :: node(),
+        Keys :: list()
+) -> any().
+on_remote_node_entries_deleted(Node, Keys) ->
+    io:format("~p entries from remote node ~p deleted from registry:
+    ~p and more...~n", [length(Keys), Node, lists:sublist(Keys, 5)]).


### PR DESCRIPTION
This PR adds a new callback to the custom event handler, so that the user can register a callback and act after all entries belonging to a remote node have been deleted from the local registry.

This might give an opportunity to understand whether we are in a temporary disconnection, or the node has crashed or simply removed from the cluster, and perform custom logic (such as logging, alerting, or spawning new processes for those keys in the remaining nodes of the cluster).

