### PR TITLE
Added function to get all registered Process Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,15 @@ Types:
     GroupName = any()
 ```
 
+To get a list of the existing groups:
+
+```erlang
+syn:get_group_names() -> [GroupName].
+
+Types:
+    GroupName = any()
+```
+
 To publish a message to all group members:
 
 ```erlang

--- a/src/syn.erl
+++ b/src/syn.erl
@@ -35,6 +35,7 @@
 -export([join/2, join/3]).
 -export([leave/2]).
 -export([get_members/1, get_members/2]).
+-export([get_group_names/0]).
 -export([member/2]).
 -export([get_local_members/1, get_local_members/2]).
 -export([local_member/2]).
@@ -145,6 +146,10 @@ get_members(GroupName) ->
 -spec get_members(GroupName :: any(), with_meta) -> [{pid(), Meta :: any()}].
 get_members(GroupName, with_meta) ->
     syn_groups:get_members(GroupName, with_meta).
+
+-spec get_group_names() -> [GroupName :: any()].
+get_group_names() ->
+    syn_groups:get_group_names().
 
 -spec member(GroupName :: any(), Pid :: pid()) -> boolean().
 member(GroupName, Pid) ->

--- a/src/syn_groups.erl
+++ b/src/syn_groups.erl
@@ -31,6 +31,7 @@
 -export([join/2, join/3]).
 -export([leave/2]).
 -export([get_members/1, get_members/2]).
+-export([get_group_names/0]).
 -export([member/2]).
 -export([get_local_members/1, get_local_members/2]).
 -export([local_member/2]).
@@ -115,6 +116,16 @@ get_members(GroupName, with_meta) ->
         [],
         [{{'$2', '$3'}}]
     }]).
+
+-spec get_group_names() -> [GroupName :: any()].
+get_group_names() ->
+    Groups = ets:select(syn_groups_by_name, [{
+      {{'$1', '_'}, '_', '_', '_'},
+      [],
+      ['$1']
+    }]),
+    Set = sets:from_list(Groups),
+    sets:to_list(Set).
 
 -spec member(Pid :: pid(), GroupName :: any()) -> boolean().
 member(Pid, GroupName) ->


### PR DESCRIPTION
This function is useful when you want to iterate over all the groups your application is using. 


Some examples:
- Unsubscribe to all topics in a pub-sub system
- Connecting to application from a "debug console"
- Sending a message to all groups