### PR TITLE
Fix Elixir config in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,9 +512,10 @@ In `config.exs` you can specify your anti-entropy settings:
 
 ```elixir
 config :syn,
-  anti_entropy:
-    registry: [interval: 300, interval_max_deviation: 60]
+  anti_entropy: [
+    registry: [interval: 300, interval_max_deviation: 60],
     groups: [interval: 300, interval_max_deviation: 60]
+  ]
 ```
 
 #### Erlang


### PR DESCRIPTION
The suggested Anti-Entropy config for Elixir produced a syntax error; this should resolve that.