### PR TITLE
fix syn_groups_by_pid leak

### DIFF
--- a/src/syn_groups.erl
+++ b/src/syn_groups.erl
@@ -490,7 +490,7 @@ remove_from_local_table(GroupName, Pid) ->
 
         _ ->
             ets:match_delete(syn_groups_by_name, {{GroupName, Pid}, '_', '_', '_'}),
-            ets:match_delete(syn_groups_by_name, {{Pid, GroupName}, '_', '_', '_'}),
+            ets:match_delete(syn_groups_by_pid, {{Pid, GroupName}, '_', '_', '_'}),
             ok
     end.
 


### PR DESCRIPTION
entries are never removed from the syn_groups_by_pid table.

this should solve the issue