### PR TITLE
Fixing type spec for dialyzer.

### DIFF
--- a/src/syn.erl
+++ b/src/syn.erl
@@ -399,7 +399,7 @@ whereis_name(Scope, Name) ->
     end.
 
 %% @private
--spec send(Name :: term(), Message :: term()) -> pid().
+-spec send(Name :: term(), Message :: term()) -> pid() | {badarg, term()}.
 send(Tuple, Message) ->
     case whereis_name(Tuple) of
         undefined ->


### PR DESCRIPTION
Hi!

We use syn in our project but the type spec of send/2 gives us a lot of dialyzer errors. It seems to ignore the return value for error case.