### PR TITLE
fix syn_pg:join/4 spec by adding the error type

### DIFF
--- a/src/syn_pg.erl
+++ b/src/syn_pg.erl
@@ -166,7 +166,7 @@ is_local_member(Scope, GroupName, Pid) ->
             end
     end.
 
--spec join(Scope :: atom(), GroupName :: term(), Pid :: pid(), Meta :: term()) -> ok.
+-spec join(Scope :: atom(), GroupName :: term(), Pid :: pid(), Meta :: term()) -> ok | {error, Reason :: term()}.
 join(Scope, GroupName, Pid, Meta) ->
     case join_or_update(Scope, GroupName, Pid, Meta) of
         {ok, _} -> ok;


### PR DESCRIPTION
the current type spec for `syn_pg:join/4` does not include the error type