### PR TITLE
Use new logger

### DIFF
--- a/src/syn_gen_scope.erl
+++ b/src/syn_gen_scope.erl
@@ -344,7 +344,7 @@ terminate(Reason, #state{handler_log_name = HandlerLogName, scope = Scope}) ->
                  #{
                    handler_name => HandlerLogName,
                    scope => Scope,
-                   report_cb => fun syn_logger:?MODULE/1,
+                   report_cb => fun syn_logger:terminate/1,
                    domain => [syn, gen_scope]
                   }).
 

--- a/src/syn_logger.erl
+++ b/src/syn_logger.erl
@@ -4,7 +4,8 @@
          terminate/1,
          callback_error/1,
          unknown_message/1,
-         scope/1]).
+         scope/1,
+         conflict/1]).
 
 syn_gen_scope(#{msg := discover, from := From}) ->
     {"Received DISCOVER request from node ~s", [From]};
@@ -41,3 +42,11 @@ unknown_message(#{kind := Kind, msg := Msg}) ->
 
 scope(#{action := added, new := Scope}) ->
     {"Added node to scope <~s>", [Scope]}.
+
+conflict(#{name := Name, remote := Remote, local := Local, keep := {none, Pid}}) ->
+    {"Registry CONFLICT for name ~p: ~p vs ~p -> none chosen: ~p",
+     [Name, Remote, Local, Pid]};
+conflict(#{name := Name, remote := Remote, local := Local, keep := Keep} = Msg) ->
+    #{Keep := {Pid, _}} = Msg,
+    {"Registry CONFLICT for name ~p: ~p vs ~p -> keeping ~s: ~p",
+     [Name, Remote, Local, Keep, Pid]}.

--- a/src/syn_logger.erl
+++ b/src/syn_logger.erl
@@ -1,0 +1,18 @@
+-module(syn_logger).
+
+-export([syn_gen_scope/1,
+         terminate/1]).
+
+syn_gen_scope(#{msg := discover, from := From}) ->
+    {"Received DISCOVER request from node ~s", [From]};
+syn_gen_scope(#{msg := {ack_sync, Data}, from := From}) ->
+    {"Received ACK SYNC (~w entries) from node ~s", [length(Data), From]};
+syn_gen_scope(#{msg := {down, Reason}, from := From}) ->
+    {"Scope Process is DOWN on node node ~s: ~p", [From, Reason]};
+syn_gen_scope(#{msg := nodeup, from := From}) ->
+    {"Node ~s has joined the cluster, sending discover message", [From]};
+syn_gen_scope(#{msg := after_init}) ->
+    {"Discover the cluster", []}.
+
+terminate(#{msg := {terminate, Reason}}) ->
+    {"Terminating with reason: ~p", [Reason]}.

--- a/src/syn_logger.erl
+++ b/src/syn_logger.erl
@@ -2,7 +2,8 @@
 
 -export([syn_gen_scope/1,
          terminate/1,
-         callback_error/1]).
+         callback_error/1,
+         unknown_message/1]).
 
 syn_gen_scope(#{msg := discover, from := From}) ->
     {"Received DISCOVER request from node ~s", [From]};
@@ -28,3 +29,11 @@ callback_error(#{class := Class,
                     fa := {Func, _},
                     stacktrace := Stacktrace}) ->
     {"Error ~p:~p in custom handler ~p: ~p", [Class, Reason, Func, Stacktrace]}.
+
+unknown_message(#{kind := down, pid := Pid, reason := Reason}) ->
+    {"Received a DOWN message from and unknown process ~p with reason: ~p",
+     [Pid, Reason]};
+unknown_message(#{kind := call, from := From, msg := Msg}) ->
+    {"Received from ~p an unknown call message: ~p", [From, Msg]};
+unknown_message(#{kind := Kind, msg := Msg}) ->
+    {"Received an unknown ~p message: ~p", [Kind, Msg]}.

--- a/src/syn_logger.erl
+++ b/src/syn_logger.erl
@@ -3,7 +3,8 @@
 -export([syn_gen_scope/1,
          terminate/1,
          callback_error/1,
-         unknown_message/1]).
+         unknown_message/1,
+         scope/1]).
 
 syn_gen_scope(#{msg := discover, from := From}) ->
     {"Received DISCOVER request from node ~s", [From]};
@@ -37,3 +38,6 @@ unknown_message(#{kind := call, from := From, msg := Msg}) ->
     {"Received from ~p an unknown call message: ~p", [From, Msg]};
 unknown_message(#{kind := Kind, msg := Msg}) ->
     {"Received an unknown ~p message: ~p", [Kind, Msg]}.
+
+scope(#{action := added, new := Scope}) ->
+    {"Added node to scope <~s>", [Scope]}.

--- a/src/syn_logger.erl
+++ b/src/syn_logger.erl
@@ -1,7 +1,8 @@
 -module(syn_logger).
 
 -export([syn_gen_scope/1,
-         terminate/1]).
+         terminate/1,
+         callback_error/1]).
 
 syn_gen_scope(#{msg := discover, from := From}) ->
     {"Received DISCOVER request from node ~s", [From]};
@@ -16,3 +17,14 @@ syn_gen_scope(#{msg := after_init}) ->
 
 terminate(#{msg := {terminate, Reason}}) ->
     {"Terminating with reason: ~p", [Reason]}.
+
+callback_error(#{class := Class,
+                    reason := Reason,
+                    mfa := {_, Func, _},
+                    stacktrace := Stacktrace}) ->
+    {"Error ~p:~p in custom handler ~p: ~p", [Class, Reason, Func, Stacktrace]};
+callback_error(#{class := Class,
+                    reason := Reason,
+                    fa := {Func, _},
+                    stacktrace := Stacktrace}) ->
+    {"Error ~p:~p in custom handler ~p: ~p", [Class, Reason, Func, Stacktrace]}.

--- a/src/syn_logger.erl
+++ b/src/syn_logger.erl
@@ -40,6 +40,8 @@ unknown_message(#{kind := call, from := From, msg := Msg}) ->
 unknown_message(#{kind := Kind, msg := Msg}) ->
     {"Received an unknown ~p message: ~p", [Kind, Msg]}.
 
+scope(#{action := tables_created, new := Scope}) ->
+    {"Created tabled for scope <~s>", [Scope]};
 scope(#{action := added, new := Scope}) ->
     {"Added node to scope <~s>", [Scope]}.
 

--- a/src/syn_pg.erl
+++ b/src/syn_pg.erl
@@ -69,6 +69,8 @@
 %% includes
 -include("syn.hrl").
 
+-include_lib("kernel/include/logger.hrl").
+
 %% ===================================================================
 %% API
 %% ===================================================================
@@ -364,10 +366,16 @@ handle_call({'3.0', join_or_update_on_node, RequesterNode, GroupName, Pid, MetaO
                             do_join_on_node(GroupName, Pid, TableMeta, Meta, MRef, normal, RequesterNode, on_group_process_updated, State)
 
                     catch Class:Reason:Stacktrace ->
-                        error_logger:error_msg(
-                            "SYN[~s] Error ~p:~p in pg update function: ~p",
-                            [node(), Class, Reason, Stacktrace]
-                        ),
+                      ?LOG_ERROR(#{
+                                   class => Class,
+                                   reason => Reason,
+                                   fa => {update, [TableMeta]},
+                                   stacktrace => Stacktrace
+                                  },
+                                 #{
+                                   report_cb => fun syn_logger:callback_error/1,
+                                   domain => [syn, pg]
+                                  }),
                         {reply, {raise, Class, Reason, Stacktrace}, State}
                     end;
 
@@ -407,9 +415,16 @@ handle_call({'3.0', leave_on_node, RequesterNode, GroupName, Pid}, _From, #state
     end;
 
 handle_call(Request, From, #state{scope = Scope} = State) ->
-    error_logger:warning_msg("SYN[~s|~s<~s>] Received from ~p an unknown call message: ~p",
-        [node(), ?MODULE_LOG_NAME, Scope, From, Request]
-    ),
+    ?LOG_WARNING(#{
+                   kind => call,
+                   from => From,
+                   msg => Request
+                  },
+                 #{
+                   scope => Scope,
+                   report_cb => fun syn_logger:unknown_message/1,
+                   domain => [syn, pg]
+                  }),
     {reply, undefined, State}.
 
 %% ----------------------------------------------------------------------------------------------------------
@@ -456,10 +471,16 @@ handle_info({'DOWN', _MRef, process, Pid, Reason}, #state{
 } = State) ->
     case find_pg_entries_by_pid(Pid, TableByPid) of
         [] ->
-            error_logger:warning_msg(
-                "SYN[~s|~s<~s>] Received a DOWN message from an unknown process ~p with reason: ~p",
-                [node(), ?MODULE_LOG_NAME, Scope, Pid, Reason]
-            );
+            ?LOG_WARNING(#{
+                           kind => down,
+                           pid => Pid,
+                           reason => Reason
+                          },
+                         #{
+                           scope => Scope,
+                           report_cb => fun syn_logger:unknown_message/1,
+                           domain => [syn, pg]
+                          });
 
         Entries ->
             lists:foreach(fun({{_Pid, GroupName}, Meta, _, _, _}) ->
@@ -475,7 +496,15 @@ handle_info({'DOWN', _MRef, process, Pid, Reason}, #state{
     {noreply, State};
 
 handle_info(Info, #state{scope = Scope} = State) ->
-    error_logger:warning_msg("SYN[~s|~s<~s>] Received an unknown info message: ~p", [node(), ?MODULE_LOG_NAME, Scope, Info]),
+    ?LOG_WARNING(#{
+                   kind => info,
+                   msg => Info
+                  },
+                 #{
+                   scope => Scope,
+                   report_cb => fun syn_logger:unknown_message/1,
+                   domain => [syn, pg]
+                  }),
     {noreply, State}.
 
 %% ----------------------------------------------------------------------------------------------------------

--- a/src/syn_sup.erl
+++ b/src/syn_sup.erl
@@ -37,6 +37,8 @@
 %% includes
 -include("syn.hrl").
 
+-include_lib("kernel/include/logger.hrl").
+
 %% ===================================================================
 %% API
 %% ===================================================================
@@ -50,7 +52,6 @@ node_scopes() ->
 
 -spec add_node_to_scope(Scope :: atom()) -> ok.
 add_node_to_scope(Scope) when is_atom(Scope) ->
-    error_logger:info_msg("SYN[~s] Adding node to scope <~s>", [node(), Scope]),
     Scopes0 = node_scopes(),
     case lists:member(Scope, Scopes0) of
         true ->
@@ -64,6 +65,16 @@ add_node_to_scope(Scope) when is_atom(Scope) ->
             application:set_env(syn, scopes, Scopes),
             %% start child
             supervisor:start_child(?MODULE, child_spec(Scope)),
+
+            ?LOG_INFO(#{
+                        action => added,
+                        new => Scope,
+                        prev => Scopes0
+                       },
+                      #{
+                        report_cb => fun syn_logger:scope/1,
+                        domain => [syn]
+                       }),
             ok
     end.
 

--- a/test/syn_test_suite_helper.erl
+++ b/test/syn_test_suite_helper.erl
@@ -40,7 +40,6 @@
 -export([assert_received_messages/1]).
 -export([assert_empty_queue/0]).
 -export([assert_wait/2]).
--export([send_error_logger_to_disk/0]).
 
 %% internal
 -export([process_main/0]).
@@ -307,9 +306,6 @@ assert_wait(ExpectedResult, Fun, StartAt) ->
                     assert_wait(ExpectedResult, Fun, StartAt)
             end
     end.
-
-send_error_logger_to_disk() ->
-    error_logger:logfile({open, atom_to_list(node())}).
 
 %% ===================================================================
 %% Internal


### PR DESCRIPTION
Some data from current messages is moved to metadata, which mean that without user action, these will not be shown in default output.

All messages are now bout stuff that happened in the past, not about stuff that is about to happen (that was about scope messages).

For now I have translated messages' levels 1:1, but some probably could have their levels altered to debug and notice levels.

Everything is done via structured logging.

Close #80 